### PR TITLE
feat: add natural command flow for deploy and get CLI commands

### DIFF
--- a/cmd/cli/command/deploy.go
+++ b/cmd/cli/command/deploy.go
@@ -31,7 +31,6 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 	var version string
 	var ns string
 	var app string
-	var kind string
 	var name string
 	var file string
 	deployCmd := &cobra.Command{
@@ -39,7 +38,7 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 		Short: "Helps you create and deploy a sailor resource",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return errors.New("flags or env as argument is required")
+				return errors.New("subcommand is required")
 			}
 
 			return nil
@@ -49,8 +48,34 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 	deployCmd.PersistentFlags().StringVarP(&file, "file", "", "", "resource data file")
 	deployCmd.PersistentFlags().StringVarP(&ns, "namespace", "", "", "resource from this namespace")
 	deployCmd.PersistentFlags().StringVarP(&app, "app", "", "", "resource for this app")
-	deployCmd.PersistentFlags().StringVarP(&kind, "kind", "", "", "kind of resource (config,secret,misc)")
 	deployCmd.PersistentFlags().StringVarP(&name, "name", "", "", "name of the misc resource")
+
+	// Config subcommand
+	config := &cobra.Command{
+		Use:   "config",
+		Short: "Helps you deploy a sailor config",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deployResource(cfg, "config", ns, app, name, file)
+		},
+	}
+
+	// Secret subcommand
+	secret := &cobra.Command{
+		Use:   "secret",
+		Short: "Helps you deploy a sailor secret",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deployResource(cfg, "secret", ns, app, name, file)
+		},
+	}
+
+	// Misc subcommand
+	misc := &cobra.Command{
+		Use:   "misc",
+		Short: "Helps you deploy a misc resource",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deployResource(cfg, "misc", ns, app, name, file)
+		},
+	}
 
 	create := &cobra.Command{
 		Use:   "create",
@@ -60,7 +85,13 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 				return errors.New("resource data file not provided")
 			}
 
-			if ns != "" && app != "" && kind != "" {
+			if ns != "" && app != "" {
+				// Get kind from args
+				if len(args) == 0 {
+					return errors.New("kind is required as argument (config, secret, misc)")
+				}
+
+				kind := args[0]
 				if !slices.Contains([]string{"config", "misc", "secret"}, kind) {
 					return errors.New("not a valid kind of resource")
 				}
@@ -125,7 +156,13 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 				version = "all"
 			}
 
-			if ns != "" && app != "" && version != "" && kind != "" {
+			if ns != "" && app != "" && version != "" {
+				// Get kind from args
+				if len(args) == 0 {
+					return errors.New("kind is required as argument (config, secret, misc)")
+				}
+
+				kind := args[0]
 				if !slices.Contains([]string{"config", "misc", "secret"}, kind) {
 					return errors.New("not a valid kind of resource")
 				}
@@ -164,7 +201,13 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 		Use:   "apply",
 		Short: "Helps you create apply sailor resource",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if ns != "" && app != "" && version != "" && kind != "" {
+			if ns != "" && app != "" && version != "" {
+				// Get kind from args
+				if len(args) == 0 {
+					return errors.New("kind is required as argument (config, secret, misc)")
+				}
+
+				kind := args[0]
 				if err := cfg.SailorClient.Deploy(ns, app, kind, name, cfg.Token, version); err != nil {
 					return err
 				}
@@ -181,8 +224,64 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 	}
 	apply.Flags().StringVarP(&version, "version", "v", "", "deploy this specific version")
 
+	deployCmd.AddCommand(config)
+	deployCmd.AddCommand(secret)
+	deployCmd.AddCommand(misc)
 	deployCmd.AddCommand(create)
 	deployCmd.AddCommand(list)
 	deployCmd.AddCommand(apply)
 	return deployCmd
+}
+
+// Helper function for deploying resources
+func deployResource(cfg *CLIConfig, kind, ns, app, name, file string) error {
+	if file == "" {
+		return errors.New("resource data file not provided")
+	}
+
+	if ns == "" || app == "" {
+		return errors.New("namespace and app are required")
+	}
+
+	if kind == "misc" && name == "" {
+		return errors.New("resource name is required for misc kind")
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("description: ")
+	desc, _ := reader.ReadString('\n')
+	if desc == "" {
+		return errors.New("deployment description is required")
+	}
+
+	var data any
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	switch kind {
+	case "config":
+		var d map[string]any
+		if err := json.Unmarshal(b, &d); err != nil {
+			return err
+		}
+		data = d
+	case "secret":
+		var d map[string]string
+		if err := json.Unmarshal(b, &d); err != nil {
+			return err
+		}
+		data = d
+	case "misc":
+		data = string(b)
+	}
+
+	version, err := cfg.SailorClient.CreateDeployment(ns, app, kind, name, cfg.Token, strings.TrimSpace(desc), data)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Deployment: %v created!\n", *version)
+	return nil
 }

--- a/cmd/cli/command/deploy.go
+++ b/cmd/cli/command/deploy.go
@@ -27,6 +27,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// deployResourceCommand creates a command for deploying a specific resource type
+func deployResourceCommand(cfg *CLIConfig, kind string, ns, app, name, file *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   kind,
+		Short: "Helps you deploy a sailor " + kind,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deployResource(cfg, kind, *ns, *app, *name, *file)
+		},
+	}
+}
+
 func DeployCommand(cfg *CLIConfig) *cobra.Command {
 	var version string
 	var ns string
@@ -38,7 +49,7 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 		Short: "Helps you create and deploy a sailor resource",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return errors.New("subcommand is required")
+				return ErrKindArgumentMissing
 			}
 
 			return nil
@@ -51,31 +62,13 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 	deployCmd.PersistentFlags().StringVarP(&name, "name", "", "", "name of the misc resource")
 
 	// Config subcommand
-	config := &cobra.Command{
-		Use:   "config",
-		Short: "Helps you deploy a sailor config",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return deployResource(cfg, "config", ns, app, name, file)
-		},
-	}
+	config := deployResourceCommand(cfg, "config", &ns, &app, &name, &file)
 
 	// Secret subcommand
-	secret := &cobra.Command{
-		Use:   "secret",
-		Short: "Helps you deploy a sailor secret",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return deployResource(cfg, "secret", ns, app, name, file)
-		},
-	}
+	secret := deployResourceCommand(cfg, "secret", &ns, &app, &name, &file)
 
 	// Misc subcommand
-	misc := &cobra.Command{
-		Use:   "misc",
-		Short: "Helps you deploy a misc resource",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return deployResource(cfg, "misc", ns, app, name, file)
-		},
-	}
+	misc := deployResourceCommand(cfg, "misc", &ns, &app, &name, &file)
 
 	create := &cobra.Command{
 		Use:   "create",
@@ -88,7 +81,7 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 			if ns != "" && app != "" {
 				// Get kind from args
 				if len(args) == 0 {
-					return errors.New("kind is required as argument (config, secret, misc)")
+					return ErrKindArgumentMissing
 				}
 
 				kind := args[0]
@@ -159,7 +152,7 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 			if ns != "" && app != "" && version != "" {
 				// Get kind from args
 				if len(args) == 0 {
-					return errors.New("kind is required as argument (config, secret, misc)")
+					return ErrKindArgumentMissing
 				}
 
 				kind := args[0]
@@ -204,7 +197,7 @@ func DeployCommand(cfg *CLIConfig) *cobra.Command {
 			if ns != "" && app != "" && version != "" {
 				// Get kind from args
 				if len(args) == 0 {
-					return errors.New("kind is required as argument (config, secret, misc)")
+					return ErrKindArgumentMissing
 				}
 
 				kind := args[0]

--- a/cmd/cli/command/errors.go
+++ b/cmd/cli/command/errors.go
@@ -1,0 +1,22 @@
+// sailor
+// Copyright (C) 2025 SailorHQ and Ashish Shekar (codekidX)
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package command
+
+import "errors"
+
+var (
+	ErrKindArgumentMissing = errors.New("kind or env as argument is required")
+)

--- a/cmd/cli/command/get.go
+++ b/cmd/cli/command/get.go
@@ -26,6 +26,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// getResourceCommand creates a command for getting a specific resource type
+func getResourceCommand(cfg *CLIConfig, kind string, ns, app, name, output *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   kind,
+		Short: "Helps you get a sailor " + kind,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getResource(cfg, kind, *ns, *app, *name, *output)
+		},
+	}
+}
+
 func GetCommand(cfg *CLIConfig) *cobra.Command {
 	var ns string
 	var app string
@@ -45,31 +56,13 @@ func GetCommand(cfg *CLIConfig) *cobra.Command {
 	getCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "output the resource data into a file")
 
 	// Config subcommand
-	config := &cobra.Command{
-		Use:   "config",
-		Short: "Helps you get a sailor config",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return getResource(cfg, "config", ns, app, name, output)
-		},
-	}
+	config := getResourceCommand(cfg, "config", &ns, &app, &name, &output)
 
 	// Secret subcommand
-	secret := &cobra.Command{
-		Use:   "secret",
-		Short: "Helps you get a sailor secret",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return getResource(cfg, "secret", ns, app, name, output)
-		},
-	}
+	secret := getResourceCommand(cfg, "secret", &ns, &app, &name, &output)
 
 	// Misc subcommand
-	misc := &cobra.Command{
-		Use:   "misc",
-		Short: "Helps you get a misc resource",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return getResource(cfg, "misc", ns, app, name, output)
-		},
-	}
+	misc := getResourceCommand(cfg, "misc", &ns, &app, &name, &output)
 
 	schema := &cobra.Command{
 		Use:   "schema",
@@ -78,7 +71,7 @@ func GetCommand(cfg *CLIConfig) *cobra.Command {
 			if ns != "" && app != "" {
 				// Get kind from args
 				if len(args) == 0 {
-					return errors.New("kind is required as argument (config, secret, misc)")
+					return ErrKindArgumentMissing
 				}
 
 				kind := args[0]
@@ -176,7 +169,7 @@ func GetCommand(cfg *CLIConfig) *cobra.Command {
 			if ns != "" && app != "" {
 				// Get kind from args
 				if len(args) == 0 {
-					return errors.New("kind is required as argument (config, secret, misc)")
+					return ErrKindArgumentMissing
 				}
 
 				kind := args[0]

--- a/cmd/cli/command/get.go
+++ b/cmd/cli/command/get.go
@@ -29,7 +29,6 @@ import (
 func GetCommand(cfg *CLIConfig) *cobra.Command {
 	var ns string
 	var app string
-	var kind string
 	var name string
 	var output string
 	getCmd := &cobra.Command{
@@ -42,15 +41,47 @@ func GetCommand(cfg *CLIConfig) *cobra.Command {
 
 	getCmd.PersistentFlags().StringVarP(&ns, "namespace", "", "", "get resource from this namespace")
 	getCmd.PersistentFlags().StringVarP(&app, "app", "", "", "get resource from this app")
-	getCmd.PersistentFlags().StringVarP(&kind, "kind", "", "", "kind of resource")
 	getCmd.PersistentFlags().StringVarP(&name, "name", "", "", "name of the misc resource")
 	getCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "output the resource data into a file")
+
+	// Config subcommand
+	config := &cobra.Command{
+		Use:   "config",
+		Short: "Helps you get a sailor config",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getResource(cfg, "config", ns, app, name, output)
+		},
+	}
+
+	// Secret subcommand
+	secret := &cobra.Command{
+		Use:   "secret",
+		Short: "Helps you get a sailor secret",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getResource(cfg, "secret", ns, app, name, output)
+		},
+	}
+
+	// Misc subcommand
+	misc := &cobra.Command{
+		Use:   "misc",
+		Short: "Helps you get a misc resource",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getResource(cfg, "misc", ns, app, name, output)
+		},
+	}
 
 	schema := &cobra.Command{
 		Use:   "schema",
 		Short: "Helps you fetch schema for a resource",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if ns != "" && app != "" && kind != "" {
+			if ns != "" && app != "" {
+				// Get kind from args
+				if len(args) == 0 {
+					return errors.New("kind is required as argument (config, secret, misc)")
+				}
+
+				kind := args[0]
 				if kind == "misc" && name == "" {
 					return errors.New("misc resource requires a name")
 				}
@@ -86,7 +117,8 @@ func GetCommand(cfg *CLIConfig) *cobra.Command {
 		Use:   "setting",
 		Short: "Helps you fetch resource or sailor setting",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if ns != "" && app != "" && kind != "" {
+			if ns != "" && app != "" && len(args) > 0 {
+				kind := args[0]
 				if kind == "misc" && name == "" {
 					return errors.New("misc resource requires a name")
 				}
@@ -141,7 +173,13 @@ func GetCommand(cfg *CLIConfig) *cobra.Command {
 		Use:   "resource",
 		Short: "Helps you fetch a specific resource",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if ns != "" && app != "" && kind != "" {
+			if ns != "" && app != "" {
+				// Get kind from args
+				if len(args) == 0 {
+					return errors.New("kind is required as argument (config, secret, misc)")
+				}
+
+				kind := args[0]
 				if !slices.Contains([]string{"config", "misc", "secret"}, kind) {
 					return errors.New("not a valid kind of resource")
 				}
@@ -150,54 +188,7 @@ func GetCommand(cfg *CLIConfig) *cobra.Command {
 					return errors.New("resource name is required for misc kind")
 				}
 
-				projectKey := fmt.Sprintf("%s-%s", ns, app)
-				if _, ok := cfg.KeyPairs[projectKey]; !ok {
-					return errors.New("access not available, re-login to get fresh access")
-				}
-
-				dataBytes, err := cfg.SailorClient.GetResource(ns, app, kind, name, cfg.Token, cfg.KeyPairs[projectKey])
-				if err != nil {
-					return err
-				}
-
-				if kind == "secret" {
-					var encSecrets map[string]vault.SecretRecord
-					if err := json.Unmarshal(dataBytes, &encSecrets); err != nil {
-						return err
-					}
-
-					kek, err := vault.DeriveKEK(cfg.KeyPairs[projectKey].SecretKey, []byte(cfg.KeyPairs[projectKey].AccessKey))
-					if err != nil {
-						return err
-					}
-
-					var secrets = make(map[string]string, len(encSecrets))
-					for k, ev := range encSecrets {
-						dek, err := vault.DecryptDEK(ev.EncryptedDEK, kek)
-						if err != nil {
-							return err
-						}
-						v, err := vault.DecryptWithDEK(ev.EncryptedSecret, dek)
-						if err != nil {
-							return err
-						}
-
-						secrets[k] = v
-					}
-
-					dataBytes, err = json.Marshal(&secrets)
-					if err != nil {
-						return err
-					}
-				}
-
-				if output != "" {
-					fmt.Println("resource written to:", output)
-					return os.WriteFile(output, dataBytes, 0755)
-				}
-
-				fmt.Println(string(dataBytes))
-				return nil
+				return getResource(cfg, kind, ns, app, name, output)
 			}
 
 			fmt.Println("missing ns, app, kind or name")
@@ -205,8 +196,71 @@ func GetCommand(cfg *CLIConfig) *cobra.Command {
 		},
 	}
 
+	getCmd.AddCommand(config)
+	getCmd.AddCommand(secret)
+	getCmd.AddCommand(misc)
 	getCmd.AddCommand(schema)
 	getCmd.AddCommand(setting)
 	getCmd.AddCommand(resource)
 	return getCmd
+}
+
+// Helper function for getting resources
+func getResource(cfg *CLIConfig, kind, ns, app, name, output string) error {
+	if ns == "" || app == "" {
+		return errors.New("namespace and app are required")
+	}
+
+	if kind == "misc" && name == "" {
+		return errors.New("resource name is required for misc kind")
+	}
+
+	projectKey := fmt.Sprintf("%s-%s", ns, app)
+	if _, ok := cfg.KeyPairs[projectKey]; !ok {
+		return errors.New("access not available, re-login to get fresh access")
+	}
+
+	dataBytes, err := cfg.SailorClient.GetResource(ns, app, kind, name, cfg.Token, cfg.KeyPairs[projectKey])
+	if err != nil {
+		return err
+	}
+
+	if kind == "secret" {
+		var encSecrets map[string]vault.SecretRecord
+		if err := json.Unmarshal(dataBytes, &encSecrets); err != nil {
+			return err
+		}
+
+		kek, err := vault.DeriveKEK(cfg.KeyPairs[projectKey].SecretKey, []byte(cfg.KeyPairs[projectKey].AccessKey))
+		if err != nil {
+			return err
+		}
+
+		var secrets = make(map[string]string, len(encSecrets))
+		for k, ev := range encSecrets {
+			dek, err := vault.DecryptDEK(ev.EncryptedDEK, kek)
+			if err != nil {
+				return err
+			}
+			v, err := vault.DecryptWithDEK(ev.EncryptedSecret, dek)
+			if err != nil {
+				return err
+			}
+
+			secrets[k] = v
+		}
+
+		dataBytes, err = json.Marshal(&secrets)
+		if err != nil {
+			return err
+		}
+	}
+
+	if output != "" {
+		fmt.Println("resource written to:", output)
+		return os.WriteFile(output, dataBytes, 0755)
+	}
+
+	fmt.Println(string(dataBytes))
+	return nil
 }


### PR DESCRIPTION
## CLI: Implement Natural Command Flow for Deploy and Get Commands

### Overview
This PR implements the proposed natural command flow for the `deploy` and `get` CLI commands as requested in issue #8 . The changes make the CLI more intuitive and user-friendly by using resource types as subcommands instead of requiring `--kind` flags.

### Changes Made

#### ✨ New Command Structure

**Deploy Command:**
- [x] `sailor deploy config` - Deploy a sailor config
- [x] `sailor deploy secret` - Deploy a sailor secret  
- [x] `sailor deploy misc` - Deploy a misc resource
- [x] `sailor deploy create <kind>` - Create a deployment (kind as argument)
- [x] `sailor deploy list <kind>` - List deployments (kind as argument)
- [x] `sailor deploy apply <kind>` - Apply a deployment (kind as argument)

**Get Command:**
- [x] `sailor get config` - Get a sailor config
- [x] `sailor get secret` - Get a sailor secret
- [x] `sailor get misc` - Get a misc resource
- [x] `sailor get schema <kind>` - Get schema (kind as argument)
- [x] `sailor get setting <kind>` - Get settings (kind as argument)
- [x] `sailor get resource <kind>` - Get a resource (kind as argument)

#### 🔄 Before vs After

**Before:**
```bash
sailor deploy create --kind config --namespace ns --app myapp --file config.json
sailor get resource --kind secret --namespace ns --app myapp
```
**After**
```bash
sailor deploy config --namespace ns --app myapp --file config.json
sailor get secret --namespace ns --app myapp
```