### PR TITLE
Refactor `getSailorSetting` into `Sail` interface for testing

### DIFF
--- a/cmd/sailor/handlers/authback.go
+++ b/cmd/sailor/handlers/authback.go
@@ -38,7 +38,7 @@ func (sc *SailorCore) AuthCallbackHandler(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	ss, err := getSailorSetting(sc.dbconns[BUCKET_ADMIN])
+	ss, err := sc.SailorSail.GetSailorSetting()
 	if err != nil {
 		ctx.SetStatusCode(http.StatusInternalServerError)
 		enc.Encode(ResponseMessage{Message: err.Error()})

--- a/cmd/sailor/handlers/authoidc.go
+++ b/cmd/sailor/handlers/authoidc.go
@@ -16,13 +16,10 @@
 package handlers
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/coreos/go-oidc"
-	v1 "github.com/sailorhq/sailor/pkg/core/v1"
 	"github.com/valyala/fasthttp"
-	bolt "go.etcd.io/bbolt"
 	"golang.org/x/oauth2"
 	"k8s.io/apimachinery/pkg/util/json"
 )
@@ -37,7 +34,7 @@ func (sc *SailorCore) AuthOIDCHandler(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	ss, err := getSailorSetting(sc.dbconns[BUCKET_ADMIN])
+	ss, err := sc.SailorSail.GetSailorSetting()
 	if err != nil {
 		ctx.SetStatusCode(http.StatusInternalServerError)
 		enc.Encode(ResponseMessage{Message: err.Error()})
@@ -67,26 +64,4 @@ func (sc *SailorCore) AuthOIDCHandler(ctx *fasthttp.RequestCtx) {
 
 	// TODO :: think about the state which should be passed as part of OIDC request
 	ctx.Redirect(oauth2Config.AuthCodeURL(string(fingerprint)), http.StatusFound)
-}
-
-func getSailorSetting(adminDB *bolt.DB) (*v1.SailorSetting, error) {
-	var ss v1.SailorSetting
-	err := adminDB.View(func(tx *bolt.Tx) error {
-		settingBytes := tx.Bucket([]byte(BUCKET_SETTING)).Get([]byte(KEY_SETTING))
-		if settingBytes == nil {
-			return errors.New("sailor settings not found.")
-		}
-
-		if err := json.Unmarshal(settingBytes, &ss); err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &ss, nil
 }

--- a/cmd/sailor/handlers/authoidc_test.go
+++ b/cmd/sailor/handlers/authoidc_test.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	v1 "github.com/sailorhq/sailor/pkg/core/v1"
+	"github.com/valyala/fasthttp"
+)
+
+func TestAuthOIDCHandler(t *testing.T) {
+	// happy path tests might need an actual OIDC provider to get the provider URL.
+	// We can test at least the cases where the handler fails to get setting,
+	// missing OIDC config, and no fp query param.
+
+	tests := []struct {
+		name           string
+		setupMock      func(*MockSail)
+		queryArgs      string
+		expectedStatus int
+		expectedMsg    string
+	}{
+		{
+			name: "missing fp query arg",
+			setupMock: func(m *MockSail) {},
+			queryArgs: "",
+			expectedStatus: http.StatusInternalServerError,
+			expectedMsg: "unknown caller",
+		},
+		{
+			name: "failed to get sailor setting",
+			setupMock: func(m *MockSail) {
+				m.GetSailorSettingFunc = func() (*v1.SailorSetting, error) {
+					return nil, errors.New("db error")
+				}
+			},
+			queryArgs: "fp=123",
+			expectedStatus: http.StatusInternalServerError,
+			expectedMsg: "db error",
+		},
+		{
+			name: "missing OIDC setting",
+			setupMock: func(m *MockSail) {
+				m.GetSailorSettingFunc = func() (*v1.SailorSetting, error) {
+					return &v1.SailorSetting{}, nil
+				}
+			},
+			queryArgs: "fp=123",
+			expectedStatus: http.StatusNotFound,
+			expectedMsg: "oidc sailor settings not present",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockSail := &MockSail{}
+			tc.setupMock(mockSail)
+
+			sc := &SailorCore{
+				SailorSail: mockSail,
+			}
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.URI().SetQueryString(tc.queryArgs)
+
+			sc.AuthOIDCHandler(ctx)
+
+			if ctx.Response.StatusCode() != tc.expectedStatus {
+				t.Errorf("expected status %d, got %d", tc.expectedStatus, ctx.Response.StatusCode())
+			}
+
+			var resp ResponseMessage
+			err := json.Unmarshal(ctx.Response.Body(), &resp)
+			if err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+
+			if resp.Message != tc.expectedMsg {
+				t.Errorf("expected message '%s', got '%s'", tc.expectedMsg, resp.Message)
+			}
+		})
+	}
+}

--- a/cmd/sailor/handlers/getmanifest.go
+++ b/cmd/sailor/handlers/getmanifest.go
@@ -24,7 +24,7 @@ import (
 func (sc *SailorCore) GetManifestHandler(ctx *fasthttp.RequestCtx) {
 	enc := json.NewEncoder(ctx)
 	enc.SetEscapeHTML(false)
-	ss, err := getSailorSetting(sc.dbconns[BUCKET_ADMIN])
+	ss, err := sc.SailorSail.GetSailorSetting()
 	if err != nil {
 		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 		enc.Encode(ResponseMessage{"sailor settings not found"})

--- a/cmd/sailor/handlers/mocks_test.go
+++ b/cmd/sailor/handlers/mocks_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"github.com/sailorhq/sailor/internal/types"
+	v1 "github.com/sailorhq/sailor/pkg/core/v1"
+)
+
+type MockSail struct {
+	GetSailorSettingFunc func() (*v1.SailorSetting, error)
+	CreateProjectFunc    func(ns, app string) error
+	GetProjectsFunc      func() ([]types.Project, error)
+	GetCurrentDeployedVersionFunc func(projectKey, kind string) uint32
+	GetResourceKeysFunc  func(projectKey string) ([]string, error)
+	GetPinnedVersionFunc func(projectKey, kind, releaseVer string) (uint32, error)
+	BuildResourceFunc    func(projectKey, resourceKey, versionKey string, onTopOfLastDeployment bool, overrideMaxVersion []byte) (string, uint32)
+}
+
+func (m *MockSail) GetSailorSetting() (*v1.SailorSetting, error) {
+	if m.GetSailorSettingFunc != nil {
+		return m.GetSailorSettingFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockSail) CreateProject(ns, app string) error {
+	if m.CreateProjectFunc != nil {
+		return m.CreateProjectFunc(ns, app)
+	}
+	return nil
+}
+
+func (m *MockSail) GetProjects() ([]types.Project, error) {
+	if m.GetProjectsFunc != nil {
+		return m.GetProjectsFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockSail) GetCurrentDeployedVersion(projectKey, kind string) uint32 {
+	if m.GetCurrentDeployedVersionFunc != nil {
+		return m.GetCurrentDeployedVersionFunc(projectKey, kind)
+	}
+	return 0
+}
+
+func (m *MockSail) GetResourceKeys(projectKey string) ([]string, error) {
+	if m.GetResourceKeysFunc != nil {
+		return m.GetResourceKeysFunc(projectKey)
+	}
+	return nil, nil
+}
+
+func (m *MockSail) GetPinnedVersion(projectKey, kind, releaseVer string) (uint32, error) {
+	if m.GetPinnedVersionFunc != nil {
+		return m.GetPinnedVersionFunc(projectKey, kind, releaseVer)
+	}
+	return 0, nil
+}
+
+func (m *MockSail) BuildResource(projectKey, resourceKey, versionKey string, onTopOfLastDeployment bool, overrideMaxVersion []byte) (string, uint32) {
+	if m.BuildResourceFunc != nil {
+		return m.BuildResourceFunc(projectKey, resourceKey, versionKey, onTopOfLastDeployment, overrideMaxVersion)
+	}
+	return "", 0
+}

--- a/cmd/sailor/handlers/types.go
+++ b/cmd/sailor/handlers/types.go
@@ -235,7 +235,7 @@ func NewSailorCore() *SailorCore {
 	}
 
 	sc.Log.Info("trying to get sailor settings")
-	ss, err := getSailorSetting(sc.dbconns[BUCKET_ADMIN])
+	ss, err := sc.SailorSail.GetSailorSetting()
 	if err != nil {
 		// sailor exits here... because tokenkey is required for authentication
 		sc.Log.Fatal("unable to load settings", zap.Error(err))

--- a/cmd/sailor/sail/index.go
+++ b/cmd/sailor/sail/index.go
@@ -9,11 +9,13 @@ import (
 	"github.com/sailorhq/sailor/internal/bige"
 	"github.com/sailorhq/sailor/internal/constants"
 	"github.com/sailorhq/sailor/internal/types"
+	v1 "github.com/sailorhq/sailor/pkg/core/v1"
 	diffmod "github.com/sergi/go-diff/diffmatchpatch"
 	bolt "go.etcd.io/bbolt"
 )
 
 type Sail interface {
+	GetSailorSetting() (*v1.SailorSetting, error)
 	CreateProject(ns, app string) error
 	GetProjects() ([]types.Project, error)
 	GetCurrentDeployedVersion(projectKey, kind string) uint32
@@ -32,6 +34,28 @@ type CoreSail struct {
 	Audit *bolt.DB
 
 	ProjectMap map[string]*bolt.DB
+}
+
+func (cs *CoreSail) GetSailorSetting() (*v1.SailorSetting, error) {
+	var ss v1.SailorSetting
+	err := cs.Admin.View(func(tx *bolt.Tx) error {
+		settingBytes := tx.Bucket([]byte(constants.BUCKET_SETTING)).Get([]byte(constants.KEY_SETTING))
+		if settingBytes == nil {
+			return errors.New("sailor settings not found.")
+		}
+
+		if err := json.Unmarshal(settingBytes, &ss); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &ss, nil
 }
 
 func (cs *CoreSail) CreateProject(ns, app string) error {

--- a/internal/constants/index.go
+++ b/internal/constants/index.go
@@ -13,6 +13,14 @@ const (
 	// sailor instance, this bucket lives inside [BUCKET_ADMIN]
 	BUCKET_PROJECTS = "projects"
 
+	// BUCKET_SETTING is collection of sailor wide settings this
+	// buckect lives inside [BUCKET_ADMIN]
+	BUCKET_SETTING = "settings"
+
+	// KEY_SETTING is used to save sailor wide settings this
+	// key lives inside [BUCKET_ADMIN]
+	KEY_SETTING = "settings"
+
 	// BUCKET_RESOURCE contains all the resources present in a project
 	BUCKET_RESOURCE = "resource"
 


### PR DESCRIPTION
Abstracts `getSailorSetting` logic into the mockable `Sail` interface. Updated all relevant handlers to use this interface, allowing proper unit testing. Tests were added for `AuthOIDCHandler` using the new `MockSail`.

---
*PR created automatically by Jules for task [2145538732410432723](https://jules.google.com/task/2145538732410432723) started by @codekidX*