### PR TITLE
feat: Add admin POST APIs for plug signals

### DIFF
--- a/cmd/sailor/handlers/plugs.go
+++ b/cmd/sailor/handlers/plugs.go
@@ -50,6 +50,12 @@ func (sc *SailorCore) PostProjectCreateSignalHandler(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	if req.Ns == "" || req.App == "" {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		enc.Encode(ResponseMessage{Message: "missing required fields"})
+		return
+	}
+
 	if err := sc.plugman.FireProjectCreate(&req); err != nil {
 		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 		enc.Encode(ResponseMessage{Message: err.Error()})
@@ -66,6 +72,12 @@ func (sc *SailorCore) PostDeploySignalHandler(ctx *fasthttp.RequestCtx) {
 	if err := json.Unmarshal(ctx.Request.Body(), &req); err != nil {
 		ctx.SetStatusCode(fasthttp.StatusBadRequest)
 		enc.Encode(ResponseMessage{Message: "invalid request body"})
+		return
+	}
+
+	if req.Ns == "" || req.App == "" || req.Kind == "" || req.ResourceKey == "" || req.Version == 0 || len(req.Content) == 0 {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		enc.Encode(ResponseMessage{Message: "missing required fields"})
 		return
 	}
 

--- a/cmd/sailor/handlers/plugs.go
+++ b/cmd/sailor/handlers/plugs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/valyala/fasthttp"
+	plugrpc "github.com/sailorhq/plug/sdk/proto"
 )
 
 type PlugResponse struct {
@@ -37,4 +38,42 @@ func (sc *SailorCore) GetSailorPlugsHandler(ctx *fasthttp.RequestCtx) {
 	}
 
 	enc.Encode(response)
+}
+
+func (sc *SailorCore) PostProjectCreateSignalHandler(ctx *fasthttp.RequestCtx) {
+	enc := json.NewEncoder(ctx)
+
+	var req plugrpc.ProjectCreateRequest
+	if err := json.Unmarshal(ctx.Request.Body(), &req); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		enc.Encode(ResponseMessage{Message: "invalid request body"})
+		return
+	}
+
+	if err := sc.plugman.FireProjectCreate(&req); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		enc.Encode(ResponseMessage{Message: err.Error()})
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusNoContent)
+}
+
+func (sc *SailorCore) PostDeploySignalHandler(ctx *fasthttp.RequestCtx) {
+	enc := json.NewEncoder(ctx)
+
+	var req plugrpc.DeployRequest
+	if err := json.Unmarshal(ctx.Request.Body(), &req); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		enc.Encode(ResponseMessage{Message: "invalid request body"})
+		return
+	}
+
+	if err := sc.plugman.FireDeploy(&req); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		enc.Encode(ResponseMessage{Message: err.Error()})
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusNoContent)
 }

--- a/cmd/sailor/handlers/plugs_test.go
+++ b/cmd/sailor/handlers/plugs_test.go
@@ -23,6 +23,28 @@ func TestPostProjectCreateSignalHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
+			name: "missing required fields (app)",
+			body: func() []byte {
+				req := plugrpc.ProjectCreateRequest{
+					Ns: "test-ns",
+				}
+				b, _ := json.Marshal(req)
+				return b
+			}(),
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing required fields (ns)",
+			body: func() []byte {
+				req := plugrpc.ProjectCreateRequest{
+					App: "test-app",
+				}
+				b, _ := json.Marshal(req)
+				return b
+			}(),
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
 			name: "valid json body",
 			body: func() []byte {
 				req := plugrpc.ProjectCreateRequest{
@@ -66,11 +88,45 @@ func TestPostDeploySignalHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
+			name: "missing required fields (missing content)",
+			body: func() []byte {
+				req := plugrpc.DeployRequest{
+					Ns:          "test-ns",
+					App:         "test-app",
+					Kind:        "deployment",
+					ResourceKey: "res-123",
+					Version:     1,
+				}
+				b, _ := json.Marshal(req)
+				return b
+			}(),
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing required fields (missing version)",
+			body: func() []byte {
+				req := plugrpc.DeployRequest{
+					Ns:          "test-ns",
+					App:         "test-app",
+					Kind:        "deployment",
+					ResourceKey: "res-123",
+					Content:     []byte("test"),
+				}
+				b, _ := json.Marshal(req)
+				return b
+			}(),
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
 			name: "valid json body",
 			body: func() []byte {
 				req := plugrpc.DeployRequest{
-					Ns:  "test-ns",
-					App: "test-app",
+					Ns:          "test-ns",
+					App:         "test-app",
+					Kind:        "deployment",
+					ResourceKey: "res-123",
+					Version:     1,
+					Content:     []byte("test"),
 				}
 				b, _ := json.Marshal(req)
 				return b

--- a/cmd/sailor/handlers/plugs_test.go
+++ b/cmd/sailor/handlers/plugs_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	plugrpc "github.com/sailorhq/plug/sdk/proto"
+	"github.com/valyala/fasthttp"
+	"go.uber.org/zap/zaptest"
+	"github.com/sailorhq/sailor/internal/signal"
+)
+
+func TestPostProjectCreateSignalHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           []byte
+		expectedStatus int
+	}{
+		{
+			name:           "invalid json body",
+			body:           []byte("{invalid json}"),
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "valid json body",
+			body: func() []byte {
+				req := plugrpc.ProjectCreateRequest{
+					Ns:  "test-ns",
+					App: "test-app",
+				}
+				b, _ := json.Marshal(req)
+				return b
+			}(),
+			expectedStatus: http.StatusNoContent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := &SailorCore{
+				plugman: signal.NewPlugManager(zaptest.NewLogger(t)),
+			}
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.SetBody(tc.body)
+
+			sc.PostProjectCreateSignalHandler(ctx)
+
+			if ctx.Response.StatusCode() != tc.expectedStatus {
+				t.Errorf("expected status %d, got %d", tc.expectedStatus, ctx.Response.StatusCode())
+			}
+		})
+	}
+}
+
+func TestPostDeploySignalHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           []byte
+		expectedStatus int
+	}{
+		{
+			name:           "invalid json body",
+			body:           []byte("{invalid json}"),
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "valid json body",
+			body: func() []byte {
+				req := plugrpc.DeployRequest{
+					Ns:  "test-ns",
+					App: "test-app",
+				}
+				b, _ := json.Marshal(req)
+				return b
+			}(),
+			expectedStatus: http.StatusNoContent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := &SailorCore{
+				plugman: signal.NewPlugManager(zaptest.NewLogger(t)),
+			}
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.SetBody(tc.body)
+
+			sc.PostDeploySignalHandler(ctx)
+
+			if ctx.Response.StatusCode() != tc.expectedStatus {
+				t.Errorf("expected status %d, got %d", tc.expectedStatus, ctx.Response.StatusCode())
+			}
+		})
+	}
+}

--- a/cmd/sailor/routes/settings.go
+++ b/cmd/sailor/routes/settings.go
@@ -49,4 +49,14 @@ func RegisterSettingRoutes(apiV1 *router.Group, core *handlers.SailorCore) {
 		Roles:       []string{RoleAdmin, RoleUser},
 		Permissions: []string{PermissionEditSignal},
 	}))
+
+	apiV1.POST("/plug/signal/project/create", core.Authenticated(core.PostProjectCreateSignalHandler, v1.RBACConstraints{
+		Roles:       []string{RoleAdmin},
+		Permissions: []string{PermissionSuperAdmin},
+	}))
+
+	apiV1.POST("/plug/signal/resource/deploy", core.Authenticated(core.PostDeploySignalHandler, v1.RBACConstraints{
+		Roles:       []string{RoleAdmin},
+		Permissions: []string{PermissionSuperAdmin},
+	}))
 }


### PR DESCRIPTION
Added admin-only POST endpoints for `ProjectCreate` and `Deploy` signals in `plugs.go`. Registered the routes in `settings.go` with appropriate RBAC constraints (`RoleAdmin` and `PermissionSuperAdmin`). Removed an intermediate bash script used during patching.

---
*PR created automatically by Jules for task [8901660499504264348](https://jules.google.com/task/8901660499504264348) started by @codekidX*